### PR TITLE
BNP12

### DIFF
--- a/nonparametrics/crosscat.jl
+++ b/nonparametrics/crosscat.jl
@@ -1,0 +1,124 @@
+using Turing, Turing.RandomMeasures
+using Plots
+using Statistics
+
+# -- generate synthetic data --
+
+# dimensionality
+P = 6
+
+# number of samples
+N = 20
+
+μ0 = ones(P).^2
+y = zeros(Int, P)
+for p = 1:P
+    K = maximum(y)
+    pk = Int[sum(y .== k) for k = 1:K]
+    y[p] = rand(ChineseRestaurantProcess(PitmanYorProcess(0.5, 1.0, p-1), pk))
+end
+
+K = maximum(y)
+μ = Vector{Vector{Vector{Float64}}}(undef, K)
+z = Vector{Vector{Int}}(undef, K)
+x = Matrix{Float64}(undef, P, N)
+for k = 1:K
+    μ[k] = Vector{Vector{Float64}}()
+    z[k] = zeros(Int, N)
+    ps = findall(y .== k)
+    for n = 1:N
+        J = maximum(z[k])
+        nj = Int[sum(z[k] .== j) for j = 1:J]
+        z[k][n] = rand(ChineseRestaurantProcess(DirichletProcess(1.0), nj))
+        
+        if z[k][n] > J
+            push!(μ[k], Vector{Float64}(undef, length(ps)))
+            for (l, p_) in enumerate(ps)
+                μ[k][z[k][n]][l] = rand(Normal(μ0[p_]))
+            end
+        end
+        
+        for (l, p_) in enumerate(ps)
+            x[p_, n] = rand(Normal(μ[k][z[k][n]][l]))
+        end 
+    end
+end
+
+# -- Turing model for cross categorization --
+
+@model CrossCat(x, μ0) = begin
+    
+    # dimensionality
+    P = size(x, 1)
+
+    # number of samples
+    N = size(x, 2)
+
+    # parameters (DP)
+    α = 1.0
+
+    # parameters (PYP)
+    d = 0.5
+    θ = 1.0
+
+    @assert length(μ0) == P
+
+    # assignments to views (dimensions)
+    y = tzeros(Int, P)
+    for p = 1:P
+        K = maximum(y)
+        pk = Int[sum(y .== k) for k = 1:K]
+        
+        # views are assignments are drawn using the CRP of a PYP
+        y[p] ~ ChineseRestaurantProcess(PitmanYorProcess(d, θ, p-1), pk)
+    end
+
+    # number of active views
+    K = maximum(y)
+   
+    # parameters of univariate distributions (we assume Gaussian for each dimension)
+    μ = Vector{Vector{Vector{Float64}}}(undef, K)
+    
+    # assignments of observations to clusters in each view
+    z = TArray{TArray{Int}}(undef, K)
+    for k = 1:K
+        μ[k] = Vector{Vector{Float64}}()
+        z[k] = tzeros(Int, N)
+
+        # find all dimensions in current view 
+        ps = findall(y .== k)
+
+        # for each observation
+        for n = 1:N
+            
+            # number of active clusters in the view
+            J = maximum(z[k])
+            nj = Int[sum(z[k] .== j) for j = 1:J]
+            
+            # draw assignment to a cluster inside a view from the CRP of a DP
+            z[k][n] ~ ChineseRestaurantProcess(DirichletProcess(α), nj)
+
+            # make new cluster if necessary
+            if z[k][n] > J
+                push!(μ[k], Vector{Float64}(undef, length(ps)))
+                for (l, p_) in enumerate(ps)
+                    # draw cluster parameters for each dimension in the view 
+                    μ[k][z[k][n]][l] ~ Normal(μ0[p_])
+                end
+            end
+
+            for (l, p_) in enumerate(ps)
+                # draw value for each dimension in the view for observation n
+                x[p_, n] ~ Normal(μ[k][z[k][n]][l])
+            end 
+        end
+    end
+    
+    return x
+end
+
+# -- sampling --
+
+model = CrossCat(x, μ0);
+chain = sample(model, Gibbs(10, HMC(1, 0.1, 5, :μ), PG(10, 1, :z, :y)))
+# TODO: this currently doesn't work due to HMC function call problems in Turing#master

--- a/nonparametrics/crp_mixtureModel.jl
+++ b/nonparametrics/crp_mixtureModel.jl
@@ -1,0 +1,2 @@
+using Turing, MCMCChains
+using RDatasets

--- a/nonparametrics/crp_mixtureModel.jl
+++ b/nonparametrics/crp_mixtureModel.jl
@@ -1,2 +1,65 @@
-using Turing, MCMCChains
-using RDatasets
+using Turing, Turing.RandomMeasures
+using RDatasets, Plots
+using Statistics
+
+# -- load dataset --
+iris = dataset("datasets", "iris")
+
+data = convert(Matrix, iris[:,1:4])
+data .-= mean(data, dims=1)
+data ./= std(data, dims=1);
+
+labels = convert(Vector, iris[:,end]);;
+
+# -- define Turing model --
+@model CRPMM(y) = begin
+
+    α = 1.0
+    D,N = size(y)
+
+    rpm = DirichletProcess(α)
+
+    z = tzeros(Int, N)
+    m = tzeros(Float64, D, N)
+    s = tzeros(Float64, D, N)
+
+    for n in 1:N
+        K = maximum(z)
+        nk = Vector{Int}(map(k -> sum(z .== k), 1:K))
+
+        z[n] ~ ChineseRestaurantProcess(rpm, nk)
+        if z[n] > K
+            for d in 1:D
+                s[d,z[n]] ~ InverseGamma(2, 3)
+                m[d,z[n]] ~ Normal(0.0, sqrt(s[d,z[n]]))
+            end
+        end
+        y[:,n] ~ MvNormal(m[:,z[n]], sqrt.(s[:,z[n]]))
+    end
+end
+
+# -- sampling --
+model = CRPMM(data')
+
+nparticles = 100
+niterations = 100
+
+chain = sample(model, PG(nparticles, niterations));
+
+# -- Extract assignments --
+Z = Array(chain[:z]);
+
+# Get number of clusters per iteration
+k = [length(unique(Z[i,:])) for i in 1:size(Z,1)];
+
+plot(k, ylabel = "Number of clusters", xlabel = "Iteration")
+savefig("crp_clusters.png")
+
+# extract true cluster assignments
+y = [findfirst(l .== unique(labels)) for l in labels]
+
+# compute rand index for each iteration
+r = [randindex(y, Int.(Z[i,:]))[2] for i in 1:size(Z,1)]
+
+plot(r, xlabel = "iteration", ylabel = "Rand index")
+savefig("crp_randindex.png")

--- a/nonparametrics/lazy_SBS.jl
+++ b/nonparametrics/lazy_SBS.jl
@@ -1,0 +1,56 @@
+using Turing, Turing.RandomMeasures
+using RDatasets, Plots
+using Statistics
+# Data
+data = [-2,2,-1.5,1.5]
+
+# Base distribution
+mu_0 = mean(data)
+sigma_0 = 4
+sigma_1 = 0.5
+tau0 = 1/sigma_0^2
+tau1 = 1/sigma_1^2
+
+# DP parameters
+alpha = 0.25
+
+# size-biased sampling process
+@model sbsimm(y, rpm) = begin
+    # Base distribution.
+    H = Normal(mu_0, sigma_0)
+
+    # Latent assignments.
+    N = length(y)
+    z = tzeros(Int, N)
+
+    # locations of Gaussians
+    x = tzeros(Float64, N)
+    
+    # probability weights 
+    J = tzeros(Float64, N)
+    
+    # assignments of observations
+    z = tzeros(Int, N)
+
+    k = 0
+    surplus = 1.0
+    for i in 1:N
+        ps = vcat(J[1:k], surplus)
+        z[i] ~ Categorical(ps)
+        if z[i] > k
+            k = k + 1
+            J[k] ~ SizeBiasedSamplingProcess(rpm, surplus)
+            x[k] ~ H
+            surplus -= J[k]
+        end
+        y[i] ~ Normal(x[z[i]], sigma_1)
+    end
+end
+
+rpm = DirichletProcess(alpha)
+
+sampler = SMC(10)
+mf = sbsimm(data, rpm)
+
+# Compute empirical posterior distribution over partitions
+samples = sample(mf, sampler)

--- a/nonparametrics/topic_model.jl
+++ b/nonparametrics/topic_model.jl
@@ -1,0 +1,131 @@
+using Turing, Turing.RandomMeasures
+using Plots, StatsPlots
+using Statistics, Random, LinearAlgebra
+
+# -- LDA model with finite number of topics --
+
+@model LDA(w) = begin
+    
+    # number of topics
+    K = 4
+
+    # number of words
+    D = 20
+    
+    # number of documents
+    M = size(w,1)
+    
+    # number of words per document
+    N = size(w,2)
+    
+    # topic distributions
+    θ = Vector{Vector}(undef, M)
+    for m = 1:M
+        θ[m] ~ Dirichlet(K, 1.0)
+    end
+
+    # word distributions
+    ψ = Vector{Vector}(undef, K)
+    for k = 1:K
+        ψ[k] ~ Dirichlet(D, 0.01)
+    end
+
+    z = Vector{Vector{Int}}(undef, M)
+
+    for m = 1:M
+        z[m] = zeros(Int, N)
+        for n = 1:N
+            # select topic for word n in document m
+            z[m][n] ~ Categorical(θ[m])
+            
+            # select symbol for word n in document m from topic z[m][n]
+            w[m,n] ~ Categorical(ψ[z[m][n]])
+        end
+    end
+    return w
+end
+
+# number of documents
+M = 2
+
+# number of words per document
+N = 10
+
+# draw from prior
+prior_LDA = LDA(fill(missing, M, N))
+X = prior_LDA()
+
+# -- LDA model with infinite many topics (nonparametric) --
+
+@model CRF_LDA(w) = begin
+
+    # number of words
+    D = 20
+    
+    # number of documents
+    M = size(w,1)
+    
+    # number of words per document
+    N = size(w,2)
+    
+    # random measure
+    rpm = DirichletProcess(1.0)
+
+    t = zeros(Int, M,N)
+    k = Vector{Vector{Int}}(undef, M)
+
+    # foreach document (restaurant)
+    for m = 1:M
+        
+        # foreach word (customer)
+        for n = 1:N
+            nk = Int[sum(t[m,:] .== j) for j in 1:maximum(t[m,:])]
+
+            # select table t[m,n] for customer n in restaurant m
+            t[m,n] ~ ChineseRestaurantProcess(rpm, nk)
+        end
+
+        # number of tables at restaurant m
+        J = maximum(t[m,:])
+        k[m] = zeros(Int, J)
+
+        # foreach table in restaurant m
+        for j in 1:J
+            kk = m > 1 ? vcat(reduce(vcat, k[1:m-1]), k[m][1:j-1]) : k[m][1:j-1]
+            mj = isempty(kk) ? zeros(Int,0) : Int[sum(kk .== d) for d in 1:maximum(kk)]
+
+            # select topic (dish) at table k
+            k[m][j] ~ ChineseRestaurantProcess(rpm, mj)
+        end
+    end
+    
+    # total number of topics
+    K = maximum(map(maximum, k))
+
+    # foreach latent topic
+    for k in 1:K
+        # draw distribution over symbols
+        θ[k] = rand(Dirichlet(D, 0.01))
+    end
+
+    # foreach document
+    for m = 1:M
+        # foreach word
+        for n = 1:N
+            # select symbol for word n in document m at table t[m,n] with topic (dish) k[m][ t[m,n] ]
+            w[m,n] ~ Categorical(θ[k[m][t[m,n]]])
+        end
+    end
+    
+    return w
+end
+
+# number of documents
+M = 2
+
+# number of words per document
+N = 10
+
+# draw from the prior
+prior_CRF_LDA = CRF_LDA(fill(missing, M, N))
+X = prior_CRF_LDA()


### PR DESCRIPTION
**This PR aims to showcase Turing for implementing BNP models.**

I plan to implement the following example models for BNP12:

- [x] CRP mixture model on Iris
- [x] topic model
- [x] CrossCat model
- [x] SMC for lazy RPM mixture models (http://approximateinference.org/2017/accepted/Bloem-ReddyEtAl2017.pdf)
- [ ] HDP-HMM as extension of https://turing.ml/tutorials/4-bayeshmm/
- [ ] infinite warped mixtures -> Stheno (GPs not NN) -- not sure I will do this as the integration of Stheno is still wip

@mlomeli1 and @yebai : Do you know other examples that are more relevant / interesting for an statistician audience? Or should we stick to those?

And do you know of any interesting datasets we could use?