### PR TITLE
Implement reparameterized stochastic volatility model

### DIFF
--- a/benchmarks/sto_volatility/stan.jl
+++ b/benchmarks/sto_volatility/stan.jl
@@ -1,4 +1,5 @@
 # Ref: https://github.com/stan-dev/example-models/blob/master/misc/moving-avg/stochastic-volatility.stan
+# Ref: https://mc-stan.org/docs/2_22/stan-users-guide/stochastic-volatility-models.html
 
 using Random: seed!
 seed!(1)
@@ -18,15 +19,20 @@ parameters {
   real mu;                     // mean log volatility
   real<lower=-1,upper=1> phi;  // persistence of volatility
   real<lower=0> sigma;         // white noise shock scale
-  vector[T] h;                 // log volatility at time t
+  vector[T] h_std;             // std log volatility at time t
+}
+transformed parameters {
+  vector[T] h = h_std * sigma;  // now h ~ normal(0, sigma)
+  h[1] /= sqrt(1 - phi * phi);  // rescale h[1]
+  h += mu;
+  for (t in 2:T)
+    h[t] += phi * (h[t-1] - mu);
 }
 model {
   phi ~ uniform(-1, 1);
   sigma ~ cauchy(0, 5);
   mu ~ cauchy(0, 10);  
-  h[1] ~ normal(mu, sigma / sqrt(1 - phi * phi));
-  for (t in 2:T)
-    h[t] ~ normal(mu + phi * (h[t - 1] -  mu), sigma);
+  h_std ~ std_normal();
   y ~ normal(0, exp(h / 2));
 }
 "


### PR DESCRIPTION
I implemented the reparameterized stochastic volatility model by copying the code from the [Stan docs](https://mc-stan.org/docs/2_22/stan-users-guide/stochastic-volatility-models.html) and translating it to Turing. I had some issues with my installation of CmdStan, so I haven't tested the Stan version yet. I quickly checked that the Turing version runs with Turing 0.9 + ForwardDiff - but unfortunately I got many warning messages about numerical errors, even with Turing master.

Turing does not keep track of the original parameters during sampling, I'm not sure if Stan does (I guess so since there's a dedicated `transformed parameters` block)?